### PR TITLE
Update leader detection and make AddServer safer

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -12,6 +12,10 @@ import (
 	"github.com/hashicorp/raft"
 )
 
+func requiredQuorum(voters int) int {
+	return (voters / 2) + 1
+}
+
 // NumVoters is a helper for calculating the number of voting peers in the
 // current raft configuration. This function ignores any autopilot state
 // and will make the calculation based on a newly retrieved Raft configuration.
@@ -36,7 +40,9 @@ func (a *Autopilot) NumVoters() (int, error) {
 // its all done will trigger autopilot to remove dead servers if there
 // are any. Servers added by this method will start in a non-voting
 // state and later on autopilot will promote them to voting status
-// if desired by the configured promoter.
+// if desired by the configured promoter. If too many removals would
+// be required that would cause leadership loss then an error is returned
+// instead of performing any Raft configuration changes.
 func (a *Autopilot) AddServer(s *Server) error {
 	cfg, err := a.getRaftConfiguration()
 	if err != nil {
@@ -44,30 +50,60 @@ func (a *Autopilot) AddServer(s *Server) error {
 		return err
 	}
 
+	var existingVoter bool
+	var voterRemovals []raft.ServerID
+	var nonVoterRemovals []raft.ServerID
+	var numVoters int
 	for _, server := range cfg.Servers {
+		if server.Suffrage == raft.Voter {
+			numVoters++
+		}
+
 		if server.Address == s.Address && server.ID == s.ID {
 			// nothing to be done as the addr and ID both already match
 			return nil
-		} else if server.Address == s.Address || server.ID == s.ID {
-			// we know that we have a partial match  so we should remove then re-add the server.
-			if err := a.removeServer(server.ID); err != nil {
-				if server.ID == s.ID {
-					return fmt.Errorf("error removing server with duplicate ID %q: %w", server.ID, err)
-				} else {
-					return fmt.Errorf("error removing server with duplicate address %q: %w", server.Address, err)
-				}
+		} else if server.ID == s.ID {
+			// special case for address updates only. In this case we should be
+			// able to update the configuration without have to first remove the server
+			if server.Suffrage == raft.Voter || server.Suffrage == raft.Staging {
+				existingVoter = true
 			}
-
-			if server.ID == s.ID {
-				a.logger.Info("removed server with duplicate ID", "id", server.ID)
+		} else if server.Address == s.Address {
+			if server.Suffrage == raft.Voter {
+				voterRemovals = append(voterRemovals, server.ID)
 			} else {
-				a.logger.Info("removed server with duplicate address", "address", server.Address)
+				nonVoterRemovals = append(nonVoterRemovals, server.ID)
 			}
 		}
 	}
 
-	if err := a.addNonVoter(s.ID, s.Address); err != nil {
-		return err
+	requiredVoters := requiredQuorum(numVoters)
+	if len(voterRemovals) > numVoters-requiredVoters {
+		return fmt.Errorf("Preventing server addition that would require removal of too many servers and cause cluster instability")
+	}
+
+	for _, id := range voterRemovals {
+		if err := a.removeServer(id); err != nil {
+			return fmt.Errorf("error removing server %q with duplicate address %q: %w", id, s.Address, err)
+		}
+		a.logger.Info("removed server with duplicate address", "address", s.Address)
+	}
+
+	for _, id := range nonVoterRemovals {
+		if err := a.removeServer(id); err != nil {
+			return fmt.Errorf("error removing server %q with duplicate address %q: %w", id, s.Address, err)
+		}
+		a.logger.Info("removed server with duplicate address", "address", s.Address)
+	}
+
+	if existingVoter {
+		if err := a.addVoter(s.ID, s.Address); err != nil {
+			return err
+		}
+	} else {
+		if err := a.addNonVoter(s.ID, s.Address); err != nil {
+			return err
+		}
 	}
 
 	// Trigger a check to remove dead servers

--- a/reconcile.go
+++ b/reconcile.go
@@ -19,6 +19,10 @@ func (a *Autopilot) reconcile() error {
 	state := a.state
 	a.stateLock.Unlock()
 
+	if state == nil || state.Leader == "" {
+		return fmt.Errorf("Cannote reconcile Raft server voting rights without a valid autopilot state")
+	}
+
 	// have the promoter calculate the required Raft changeset.
 	changes := a.promoter.CalculatePromotionsAndDemotions(conf, state)
 

--- a/reconcile_test.go
+++ b/reconcile_test.go
@@ -19,6 +19,7 @@ func TestReconcile(t *testing.T) {
 	cases := map[string]testCase{
 		"promote-one-and-filter-others-and-demotions": {
 			state: State{
+				Leader: "96be11f3-c9b9-45ab-a719-dc9472ada6fe",
 				Servers: map[raft.ServerID]*ServerState{
 					"96be11f3-c9b9-45ab-a719-dc9472ada6fe": {
 						Server: Server{
@@ -109,6 +110,7 @@ func TestReconcile(t *testing.T) {
 		},
 		"demotions-and-filter-leader-transfer": {
 			state: State{
+				Leader: "96be11f3-c9b9-45ab-a719-dc9472ada6fe",
 				Servers: map[raft.ServerID]*ServerState{
 					"96be11f3-c9b9-45ab-a719-dc9472ada6fe": {
 						Server: Server{

--- a/state_test.go
+++ b/state_test.go
@@ -146,7 +146,7 @@ func TestGatherNextStateInputs(t *testing.T) {
 		},
 	}
 
-	var leaderAddr raft.ServerAddress = "198.18.0.1:8300"
+	var leaderID raft.ServerID = "7875975d-d54b-49c1-a400-9fefcc706c67"
 
 	mdel.On("AutopilotConfig").Return(conf).Once()
 	mraft.On("GetConfiguration").Return(&raftConfigFuture{config: test3VoterRaftConfiguration}).Once()
@@ -154,20 +154,20 @@ func TestGatherNextStateInputs(t *testing.T) {
 	mraft.On("LastIndex").Return(lastIndex).Once()
 	mraft.On("Stats").Return(map[string]string{"last_log_term": "3"}).Once()
 	mdel.On("FetchServerStats", mock.Anything, servers).Return(serverStats).Once()
-	mraft.On("Leader").Return(leaderAddr).Once()
+	mraft.On("Leader").Return(raft.ServerAddress("198.18.0.1:8300")).Once()
 
 	expected := &nextStateInputs{
-		Now:           now,
-		StartTime:     ap.startTime,
-		Config:        conf,
-		State:         &State{Healthy: false},
-		RaftConfig:    &test3VoterRaftConfiguration,
-		KnownServers:  servers,
-		AliveServers:  servers,
-		LatestIndex:   lastIndex,
-		LastTerm:      lastTerm,
-		FetchedStats:  serverStats,
-		LeaderAddress: leaderAddr,
+		Now:          now,
+		StartTime:    ap.startTime,
+		Config:       conf,
+		State:        &State{Healthy: false},
+		RaftConfig:   &test3VoterRaftConfiguration,
+		KnownServers: servers,
+		AliveServers: servers,
+		LatestIndex:  lastIndex,
+		LastTerm:     lastTerm,
+		FetchedStats: serverStats,
+		LeaderID:     leaderID,
 	}
 
 	actual, err := ap.gatherNextStateInputs(context.Background())

--- a/testdata/non-voter/inputs.json
+++ b/testdata/non-voter/inputs.json
@@ -100,5 +100,5 @@
          "LastIndex": 999
       }
    },
-   "LeaderAddress": "198.18.0.1:8300"
+   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67"
 }

--- a/testdata/one-failed/inputs.json
+++ b/testdata/one-failed/inputs.json
@@ -100,5 +100,5 @@
          "LastIndex": 801
       }
    },
-   "LeaderAddress": "198.18.0.1:8300"
+   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67"
 }

--- a/testdata/staging/inputs.json
+++ b/testdata/staging/inputs.json
@@ -100,5 +100,5 @@
          "LastIndex": 999
       }
    },
-   "LeaderAddress": "198.18.0.1:8300"
+   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67"
 }

--- a/testdata/state-overrides/inputs.json
+++ b/testdata/state-overrides/inputs.json
@@ -174,5 +174,5 @@
          "LastIndex": 1000
       }
    },
-   "LeaderAddress": "198.18.0.1:8300"
+   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67"
 }

--- a/testdata/typical/inputs.json
+++ b/testdata/typical/inputs.json
@@ -100,5 +100,5 @@
          "LastIndex": 999
       }
    },
-   "LeaderAddress": "198.18.0.1:8300"
+   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67"
 }


### PR DESCRIPTION
Also prevent not being able to detect the leader from potentially causing a crash.

In some cases of restarting nodes with different addresses the leader address which raft knows about may not actually be an address in the raft configuration. Consul for example would previously prevent updating the address of a node for single or 2 node clusters as the code to do so would previously have cased the removal of the server from the configuration first so that it could be updated.

With the AddServer modifications to be able to update the address of a server without requireing removals as well as prevent unsafe removals that would cause leadership loss, the applications can now just request the server be added.