### PR TITLE
Make restarting Autopilot make more sense

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/hashicorp/raft v1.2.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/goleak v1.1.10
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/mutex.go
+++ b/mutex.go
@@ -1,0 +1,35 @@
+/*
+This code was taken from the same implementation in a branch from Consul and then
+had the package updated and the mutex type unexported.
+*/
+package autopilot
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type mutex semaphore.Weighted
+
+// New returns a Mutex that is ready for use.
+func newMutex() *mutex {
+	return (*mutex)(semaphore.NewWeighted(1))
+}
+
+func (m *mutex) Lock() {
+	_ = (*semaphore.Weighted)(m).Acquire(context.Background(), 1)
+}
+
+func (m *mutex) Unlock() {
+	(*semaphore.Weighted)(m).Release(1)
+}
+
+// TryLock acquires the mutex, blocking until resources are available or ctx is
+// done. On success, returns nil. On failure, returns ctx.Err() and leaves the
+// semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (m *mutex) TryLock(ctx context.Context) error {
+	return (*semaphore.Weighted)(m).Acquire(ctx, 1)
+}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -1,0 +1,98 @@
+package autopilot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutex(t *testing.T) {
+	t.Run("starts unlocked", func(t *testing.T) {
+		m := newMutex()
+		canLock(t, m)
+	})
+
+	t.Run("Lock blocks when locked", func(t *testing.T) {
+		m := newMutex()
+		m.Lock()
+		lockIsBlocked(t, m)
+		// needed to unblock the go routine started by lockIsBlocked
+		// in order to prevent leaking the go routine.
+		m.Unlock()
+	})
+
+	t.Run("Unlock unblocks Lock", func(t *testing.T) {
+		m := newMutex()
+		m.Lock()
+		m.Unlock() // nolint:staticcheck // SA2001 is not relevant here
+		canLock(t, m)
+	})
+
+	t.Run("TryLock acquires lock", func(t *testing.T) {
+		m := newMutex()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		t.Cleanup(cancel)
+		require.NoError(t, m.TryLock(ctx))
+		lockIsBlocked(t, m)
+		// needed to unblock the go routine and prevent a leak
+		m.Unlock()
+	})
+
+	t.Run("TryLock blocks until timeout when locked", func(t *testing.T) {
+		m := newMutex()
+		m.Lock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		t.Cleanup(cancel)
+		err := m.TryLock(ctx)
+		require.Equal(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("TryLock acquires lock before timeout", func(t *testing.T) {
+		m := newMutex()
+		m.Lock()
+
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			m.Unlock()
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		t.Cleanup(cancel)
+		err := m.TryLock(ctx)
+		require.NoError(t, err)
+	})
+
+}
+
+func canLock(t *testing.T, m *mutex) {
+	t.Helper()
+	chDone := make(chan struct{})
+	go func() {
+		m.Lock()
+		close(chDone)
+	}()
+
+	select {
+	case <-chDone:
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to acquire lock before timeout")
+	}
+}
+
+func lockIsBlocked(t *testing.T, m *mutex) {
+	t.Helper()
+	chDone := make(chan struct{})
+	go func() {
+		m.Lock()
+		close(chDone)
+	}()
+
+	select {
+	case <-chDone:
+		t.Fatal("expected Lock to block")
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/run.go
+++ b/run.go
@@ -8,13 +8,13 @@ import (
 // Start will launch the go routines in the background to perform Autopilot.
 // When the context passed in is cancelled or the Stop method is called
 // then these routines will exit.
-func (a *Autopilot) Start(ctx context.Context) error {
+func (a *Autopilot) Start(ctx context.Context) {
 	a.execLock.Lock()
 	defer a.execLock.Unlock()
 
 	// already running so there is nothing to do
 	if a.execution != nil && a.execution.status == Running {
-		return nil
+		return
 	}
 
 	ctx, shutdown := context.WithCancel(ctx)
@@ -42,7 +42,7 @@ func (a *Autopilot) Start(ctx context.Context) error {
 
 	go a.beginExecution(ctx, exec)
 	a.execution = exec
-	return nil
+	return
 }
 
 // Stop will terminate the go routines being executed to perform autopilot.

--- a/run_test.go
+++ b/run_test.go
@@ -79,9 +79,11 @@ func TestRunLifeCycle(t *testing.T) {
 
 	startTime := time.Date(2020, 11, 2, 12, 0, 0, 0, time.UTC)
 	nextStateTime := time.Date(2020, 11, 2, 12, 0, 0, 10000, time.UTC)
+	blockedStartTime := time.Date(2021, 1, 25, 16, 0, 0, 10000, time.UTC)
 
 	mtime.On("Now").Return(startTime).Once()
 	mtime.On("Now").Return(nextStateTime).Once()
+	mtime.On("Now").Return(blockedStartTime).Once()
 
 	// now validate the initial state
 	expected := &State{
@@ -161,12 +163,18 @@ func TestRunLifeCycle(t *testing.T) {
 	ap.Start(ctx)
 
 	ap.runLock.Lock()
-	require.True(t, ap.running)
-	require.NotNil(t, ap.shutdown)
+	require.NotNil(t, ap.execution)
+	require.Equal(t, Running, ap.execution.status)
+	require.NotNil(t, ap.execution.shutdown)
 	require.Equal(t, startTime, ap.startTime)
-	require.NotNil(t, ap.done)
-	require.False(t, chanIsSelectable(ap.done))
+	require.NotNil(t, ap.execution.done)
+	require.False(t, chanIsSelectable(ap.execution.done))
 	ap.runLock.Unlock()
+
+	status, ch := ap.IsRunning()
+	require.Equal(t, Running, status)
+	require.NotNil(t, ch)
+	require.False(t, chanIsSelectable(ch))
 
 	actual := ap.GetState()
 
@@ -175,10 +183,39 @@ func TestRunLifeCycle(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return chanIsSelectable(done)
 	}, time.Second, 50*time.Millisecond)
+	require.True(t, chanIsSelectable(ch))
+
+	status, ch = ap.IsRunning()
+	require.Equal(t, NotRunning, status)
+	require.NotNil(t, ch)
+	require.True(t, chanIsSelectable(ch))
 
 	done = ap.Stop()
 	require.NotNil(t, done)
 	require.True(t, chanIsSelectable(done))
-
 	require.Equal(t, expected, actual)
+
+	// simulate shutting down of the previous go routine taking a long time
+	ap.execution = &execInfo{
+		status: ShuttingDown,
+	}
+	ap.execMutex.Lock()
+
+	// start autopilot while the execution lock is held. This
+	// will cause the spawned go routine to sit idle until the
+	// lock is relinquished or until it is cancelled.
+	ap.Start(context.Background())
+	require.NotNil(t, ap.execution)
+	require.Equal(t, Running, ap.execution.status)
+	// Note that because the pre-existing state was shuttingDown
+	// then we are expecting no more calls to the various mocked
+	// interfaces to ensure that this Start never gets to the
+	// point of executing most of the code but instead gets
+	// stuck in waiting on the lock and then cancelled.
+
+	done = ap.Stop()
+	require.NotNil(t, done)
+	require.Eventually(t, func() bool {
+		return chanIsSelectable(done)
+	}, time.Second, 50*time.Millisecond)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -162,14 +162,14 @@ func TestRunLifeCycle(t *testing.T) {
 
 	ap.Start(ctx)
 
-	ap.runLock.Lock()
+	ap.execLock.Lock()
 	require.NotNil(t, ap.execution)
 	require.Equal(t, Running, ap.execution.status)
 	require.NotNil(t, ap.execution.shutdown)
 	require.Equal(t, startTime, ap.startTime)
 	require.NotNil(t, ap.execution.done)
 	require.False(t, chanIsSelectable(ap.execution.done))
-	ap.runLock.Unlock()
+	ap.execLock.Unlock()
 
 	status, ch := ap.IsRunning()
 	require.Equal(t, Running, status)
@@ -199,7 +199,7 @@ func TestRunLifeCycle(t *testing.T) {
 	ap.execution = &execInfo{
 		status: ShuttingDown,
 	}
-	ap.execMutex.Lock()
+	ap.leaderLock.Lock()
 
 	// start autopilot while the execution lock is held. This
 	// will cause the spawned go routine to sit idle until the

--- a/state_test.go
+++ b/state_test.go
@@ -250,7 +250,7 @@ func TestNextStateWithInputs(t *testing.T) {
 					"e72eb8da-604d-47cd-bd7f-69ec120ea2b7": NodeVoter,
 				}).Once()
 			},
-			setupState: func(t *testing.T, state *State) {
+			setupState: func(_ *testing.T, state *State) {
 				state.Servers = map[raft.ServerID]*ServerState{
 					"e72eb8da-604d-47cd-bd7f-69ec120ea2b7": {
 						Server: Server{},


### PR DESCRIPTION
Fixes #5 

Previously a Stop/Start could result in autopilot not running if the go routines running the background hadn’t finished stopping by the time Start was called.

There are a few changes in here to fix that.

First the running status is now tracked by a constant which can have 1 of 3 states instead of a boolean. This is to be able to represent a shutting down state.

When in the shutting down state, if Start is called it will replace the current execution info with a new one. The newly spawned go routine will however acquire and hold onto the `execMutex` for its lifetime. If it is cancelled prior to gaining that lock (this shouldn’t happen) then it should immediately exit.

The addition of the `execMutex` allows for multiple autopilot go routines to co-exist without the possibility of them stomping on each others toes.