### PR TITLE
Detect leader via the delegate

### DIFF
--- a/state.go
+++ b/state.go
@@ -75,7 +75,7 @@ func (a *Autopilot) gatherNextStateInputs(ctx context.Context) (*nextStateInputs
 	inputs.KnownServers = a.delegate.KnownServers()
 
 	// Try to retrieve leader id from the delegate.
-	for id, srv := range inputs.KnownServers{
+	for id, srv := range inputs.KnownServers {
 		if srv.IsLeader {
 			inputs.LeaderID = id
 			break

--- a/state.go
+++ b/state.go
@@ -71,16 +71,30 @@ func (a *Autopilot) gatherNextStateInputs(ctx context.Context) (*nextStateInputs
 	}
 	inputs.RaftConfig = raftConfig
 
-	leader := a.raft.Leader()
-	for _, s := range inputs.RaftConfig.Servers {
-		if s.Address == leader {
-			inputs.LeaderID = s.ID
+	// get the known servers which may include left/failed ones
+	inputs.KnownServers = a.delegate.KnownServers()
+
+	// Try to retrieve leader id from the delegate.
+	for id, srv := range inputs.KnownServers{
+		if srv.IsLeader {
+			inputs.LeaderID = id
 			break
 		}
 	}
 
+	// Delegate setting the leader information is optional. If leader detection is
+	// not successful, fallback on raft config to do the same.
 	if inputs.LeaderID == "" {
-		return nil, fmt.Errorf("cannot detect the current leader server id from its address: %s", leader)
+		leader := a.raft.Leader()
+		for _, s := range inputs.RaftConfig.Servers {
+			if s.Address == leader {
+				inputs.LeaderID = s.ID
+				break
+			}
+		}
+		if inputs.LeaderID == "" {
+			return nil, fmt.Errorf("cannot detect the current leader server id from its address: %s", leader)
+		}
 	}
 
 	// get the latest Raft index - this should be kept close to the call to
@@ -100,9 +114,6 @@ func (a *Autopilot) gatherNextStateInputs(ctx context.Context) (*nextStateInputs
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-
-	// get the known servers which may include left/failed ones
-	inputs.KnownServers = a.delegate.KnownServers()
 
 	// in most cases getting the known servers should be quick but as we cannot
 	// account for every potential delegate and prevent them from making

--- a/state_test.go
+++ b/state_test.go
@@ -81,7 +81,7 @@ func TestAliveServers(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestGatherNextStateInputsLeaderFromDelegate(t *testing.T){
+func TestGatherNextStateInputsLeaderFromDelegate(t *testing.T) {
 	mtime := NewMockTimeProvider(t)
 	mraft := NewMockRaft(t)
 	mdel := NewMockApplicationIntegration(t)
@@ -109,7 +109,7 @@ func TestGatherNextStateInputsLeaderFromDelegate(t *testing.T){
 			NodeStatus:  NodeAlive,
 			Version:     "1.9.0",
 			RaftVersion: 3,
-			IsLeader: true,
+			IsLeader:    true,
 		},
 		"ecfc5237-63c3-4b09-94b9-d5682d9ae5b1": {
 			ID:          "ecfc5237-63c3-4b09-94b9-d5682d9ae5b1",

--- a/testdata/non-voter/state.json.golden
+++ b/testdata/non-voter/state.json.golden
@@ -11,6 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -34,6 +35,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -57,6 +59,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/one-failed/state.json.golden
+++ b/testdata/one-failed/state.json.golden
@@ -11,6 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -34,6 +35,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -57,6 +59,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/staging/state.json.golden
+++ b/testdata/staging/state.json.golden
@@ -11,6 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -34,6 +35,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -57,6 +59,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/state-overrides/state.json.golden
+++ b/testdata/state-overrides/state.json.golden
@@ -11,6 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -34,6 +35,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -57,6 +59,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/typical/state.json.golden
+++ b/testdata/typical/state.json.golden
@@ -11,6 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -34,6 +35,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
@@ -57,6 +59,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },

--- a/types.go
+++ b/types.go
@@ -85,6 +85,7 @@ type Server struct {
 	Version     string
 	Meta        map[string]string
 	RaftVersion int
+	IsLeader bool
 
 	// The remaining fields are those that the promoter
 	// will fill in

--- a/types.go
+++ b/types.go
@@ -85,7 +85,7 @@ type Server struct {
 	Version     string
 	Meta        map[string]string
 	RaftVersion int
-	IsLeader bool
+	IsLeader    bool
 
 	// The remaining fields are those that the promoter
 	// will fill in


### PR DESCRIPTION
In Vault, autopilot relying on leader's address to detect the ID is opening up a failure mode.

It is possible for raft config and the running nodes to have different addresses. Vault hasn't yet done the piece where the addresses in the raft config gets updated (possibly by re-adding the existing nodes with updated addresses). The main reason for this is that adding a node is not a straight forward ritual and requires unseal keys et al.

Anyways, if the customers restart the node with a different cluster address, since autopilot expects the addresses to match, autopilot will then start erroring out and state API skips returning some servers.

To get around it, the delegate is optionally made to return a `IsLeader` as part of known servers.

This doesn't affect Consul since the old style leader detection is still in place if the detection via the delegate fails.

