### PR TITLE
Fix an issue with the server stabilization time calculations

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -147,16 +147,6 @@ type Autopilot struct {
 	// racing.
 	stateLock sync.RWMutex
 
-	// startTime is recorded so that we can make better determinations about server
-	// stability during the initial period of time after autopilot first starts.
-	// If autopilot has just started the default behavior to check if a server is
-	// stable will not work as it will ensure the server has been healthy for
-	// the configured server stabilization time. If that configure time is longer
-	// than the amount of time autopilot has been running you can run into issues
-	// with leadership flapping during some scenarios where a cluster is being
-	// brought up.
-	startTime time.Time
-
 	// removeDeadCh is used to trigger the running autopilot go routines to
 	// find and remove any dead/failed servers
 	removeDeadCh chan struct{}

--- a/run.go
+++ b/run.go
@@ -18,7 +18,6 @@ func (a *Autopilot) Start(ctx context.Context) {
 	}
 
 	ctx, shutdown := context.WithCancel(ctx)
-	a.startTime = a.time.Now()
 
 	exec := &execInfo{
 		status:   Running,
@@ -127,6 +126,21 @@ func (a *Autopilot) beginExecution(ctx context.Context, exec *execInfo) {
 		<-stateUpdaterDone
 
 		a.logger.Debug("autopilot is now stopped")
+
+		// We need to gain this lock so that we can nil out the previous state.
+		// This prevents us from accidentally tracking stale state in the event
+		// that we used to be the leader at some point in time, then weren't
+		// and now are again. In particular this will ensure that that we forget
+		// about our tracking of the firstStateTime so that once restarted, we
+		// will ignore server stabilization time just like we do the very
+		// first time this process ever was the leader.
+		//
+		// This isn't included in finishExecution so that we don't perform it
+		// if we fail to gain the leaderLock before the context gets cancelled
+		// back at the beginning of this function.
+		a.stateLock.Lock()
+		defer a.stateLock.Unlock()
+		a.state = nil
 
 		a.finishExecution(exec)
 		a.leaderLock.Unlock()

--- a/stable_promoter_test.go
+++ b/stable_promoter_test.go
@@ -30,7 +30,7 @@ func TestStablePromoter_GetNodeTypes(t *testing.T) {
 
 func TestStablePromoter_CalculatePromotionsAndDemotions(t *testing.T) {
 	state := &State{
-		startTime: time.Now().Add(-30 * time.Second),
+		firstStateTime: time.Now().Add(-30 * time.Second),
 		Servers: map[raft.ServerID]*ServerState{
 			// alread the leader - will not promote
 			"462fca30-0947-4d5c-82e0-c549b0bf5b6d": {

--- a/state.go
+++ b/state.go
@@ -27,15 +27,15 @@ func aliveServers(servers map[raft.ServerID]*Server) map[raft.ServerID]*Server {
 // nextStateInputs is the collection of values that can influence
 // creation of the next State.
 type nextStateInputs struct {
-	Now          time.Time
-	StartTime    time.Time
-	Config       *Config
-	RaftConfig   *raft.Configuration
-	KnownServers map[raft.ServerID]*Server
-	LatestIndex  uint64
-	LastTerm     uint64
-	FetchedStats map[raft.ServerID]*ServerStats
-	LeaderID     raft.ServerID
+	Now            time.Time
+	FirstStateTime time.Time
+	Config         *Config
+	RaftConfig     *raft.Configuration
+	KnownServers   map[raft.ServerID]*Server
+	LatestIndex    uint64
+	LastTerm       uint64
+	FetchedStats   map[raft.ServerID]*ServerStats
+	LeaderID       raft.ServerID
 }
 
 // gatherNextStateInputs gathers all the information that would be used to
@@ -52,9 +52,34 @@ type nextStateInputs struct {
 func (a *Autopilot) gatherNextStateInputs(ctx context.Context) (*nextStateInputs, error) {
 	// there are a lot of inputs to computing the next state so they get put into a
 	// struct so that we don't have to return 8 values.
+
+	now := a.time.Now()
+
+	// We need to pull the previous states knowledge of the first time a state was generated.
+	// This is really only important for when autopilot is first started. We will use the
+	// first state's time when determining if a server is stable. Under normal circumstances
+	// we need to just check that the current time - the servers StableSince time is greater
+	// than the configured stabilization time. However while autopilot has been running for
+	// less time than the stabilization time we need to consider all servers as stable
+	// to prevent unnecessary leader elections. Therefore its important to track the first
+	// time a state was generated so we know if we have a state old enough where there is
+	// any chance of seeing servers as stable based off that configured threshold.
+	var firstStateTime time.Time
+	a.stateLock.Lock()
+	if a.state != nil {
+		firstStateTime = a.state.firstStateTime
+	}
+	a.stateLock.Unlock()
+
+	// firstStateTime will be the zero value if we are in the process of generating
+	// the first state. In that case we set it to the now time.
+	if firstStateTime.IsZero() {
+		firstStateTime = now
+	}
+
 	inputs := &nextStateInputs{
-		Now:       a.time.Now(),
-		StartTime: a.startTime,
+		Now:            now,
+		FirstStateTime: firstStateTime,
 	}
 
 	// grab the latest autopilot configuration
@@ -157,10 +182,13 @@ func (a *Autopilot) nextState(ctx context.Context) (*State, error) {
 func (a *Autopilot) nextStateWithInputs(inputs *nextStateInputs) *State {
 	nextServers := a.nextServers(inputs)
 
+	// we record the firstStateTime so that we can ignore the server stabilization
+	// time up until the time we generated the first state becomes far enough
+	// in the past. Until that point in time all servers are considered stable.
 	newState := &State{
-		startTime: inputs.StartTime,
-		Healthy:   true,
-		Servers:   nextServers,
+		firstStateTime: inputs.FirstStateTime,
+		Healthy:        true,
+		Servers:        nextServers,
 	}
 
 	voterCount := 0

--- a/testdata/non-voter/inputs.json
+++ b/testdata/non-voter/inputs.json
@@ -1,6 +1,6 @@
 {
    "Now": "2020-11-02T15:00:00Z",
-   "StartTime": "2020-11-02T13:12:34Z",
+   "FirstStateTime": "2020-11-02T13:12:34Z",
    "Config": {
       "CleanupDeadServers": true,
       "LastContactThreshold": 200000000,

--- a/testdata/one-failed/inputs.json
+++ b/testdata/one-failed/inputs.json
@@ -1,6 +1,6 @@
 {
    "Now": "2020-11-02T15:00:00Z",
-   "StartTime": "2020-11-02T13:12:34Z",
+   "FirstStateTime": "2020-11-02T13:12:34Z",
    "Config": {
       "CleanupDeadServers": true,
       "LastContactThreshold": 200000000,

--- a/testdata/staging/inputs.json
+++ b/testdata/staging/inputs.json
@@ -1,6 +1,6 @@
 {
    "Now": "2020-11-02T15:00:00Z",
-   "StartTime": "2020-11-02T13:12:34Z",
+   "FirstStateTime": "2020-11-02T13:12:34Z",
    "Config": {
       "CleanupDeadServers": true,
       "LastContactThreshold": 200000000,

--- a/testdata/state-overrides/inputs.json
+++ b/testdata/state-overrides/inputs.json
@@ -1,6 +1,6 @@
 {
    "Now": "2020-11-02T15:00:00Z",
-   "StartTime": "2020-11-02T13:12:34Z",
+   "FirstStateTime": "2020-11-02T13:12:34Z",
    "Config": {
       "CleanupDeadServers": true,
       "LastContactThreshold": 200000000,

--- a/testdata/typical/inputs.json
+++ b/testdata/typical/inputs.json
@@ -1,6 +1,6 @@
 {
    "Now": "2020-11-02T15:00:00Z",
-   "StartTime": "2020-11-02T13:12:34Z",
+   "FirstStateTime": "2020-11-02T13:12:34Z",
    "Config": {
       "CleanupDeadServers": true,
       "LastContactThreshold": 200000000,

--- a/types.go
+++ b/types.go
@@ -167,7 +167,7 @@ type ServerStats struct {
 }
 
 type State struct {
-	startTime        time.Time
+	firstStateTime   time.Time
 	Healthy          bool
 	FailureTolerance int
 	Servers          map[raft.ServerID]*ServerState
@@ -178,14 +178,11 @@ type State struct {
 
 func (s *State) ServerStabilizationTime(c *Config) time.Duration {
 	// Only use the configured stabilization time when autopilot has
-	// been running for 110% of the configured stabilization time.
-	// Before that time we haven't been running long enough to
-	// be able to take these values into account. 110% is pretty
-	// arbitrary but with the default config would prevent the
-	// stabilization time from mattering for an extra second. This
-	// allows for leeway in how quickly we get the healthy RPC responses
-	// after autopilot is started.
-	if time.Since(s.startTime) > (c.ServerStabilizationTime*110)/100 {
+	// been running for at least as long as when the first state was
+	// generated. If it hasn't been running that long then we would
+	// guarantee that all checks against the stabilization time will
+	// fail which will result in excessive leader elections.
+	if time.Since(s.firstStateTime) > c.ServerStabilizationTime {
 		return c.ServerStabilizationTime
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -182,13 +182,13 @@ func TestServerStabilizationTime(t *testing.T) {
 	}
 
 	s := &State{
-		startTime: time.Now(),
+		firstStateTime: time.Now(),
 	}
 
 	require.Equal(t, 0*time.Nanosecond, s.ServerStabilizationTime(conf))
 
 	require.Eventually(t, func() bool {
 		return s.ServerStabilizationTime(conf) == 350*time.Millisecond
-	}, 500*time.Millisecond, 75*time.Millisecond)
+	}, 500*time.Millisecond, 50*time.Millisecond)
 
 }


### PR DESCRIPTION
We currently track server stability within the `StableSince` field of the `ServerHealth`. Whenever a server goes from healthy -> unhealthy or the reverse then we update that time to the current time (roughly, the time we record is the time when we started gathering inputs for the next state and not a timestamp for when we received a healthy response from the delegate).

In various calculations we ensure that we only promote stable servers or allow them to remain voters. A stable server is one that has been healthy for the configured `ServerStabilizationTime` which defaults to 10 seconds. There is an edge case we must consider though when autopilot first starts to gather health information on servers and make decisions about suffrage, it's possible that it has not had data long enough to satisfy the configured stabilization time. In that case our solution is to treat all healthy servers as stable. Once autopilot has been running for more than the stabilization time then we can start factoring in individual server stabilization into our calculations.

Previously we prevented autopilot from using the stabilization time by ensuring that the uptime (current time - start time) was greater than 110% of the configured stabilization time. What this missed was the fact that it was possible for autopilot to be started but the first state didn’t get computed until slightly later. This meant that the `StableSince` fields would only first be populated some amount of time after autopilot was started. This resulted in there being a small window of time where if autopilot ran its reconciliation it would see all servers as unstable and demote things improperly.

This PR modifies the behavior to track the very first time a state was computed instead of when autopilot was started. That way we can properly ignore stabilization checks when it would be impossible for them to be satisfied.

I also found one potential race condition around the startTime that was being tracked. In particular it was always set when start was called even if the previous execution was still in the process of being stopped and may yet read the value. This race condition was still present after the change to tracking the first state time instead. So I updated the `finishExecution` method which gets called whenever any execution is finishing so that it will nil the tracked state. This likely also prevents other potential bugs where a long running process goes from being the leader, to a follower and then back to a leader with autopilot transitioning from running to stopped accordingly.