### PR TITLE
Zero out the state when restarted instead of nilling the pointer

### DIFF
--- a/run.go
+++ b/run.go
@@ -127,7 +127,7 @@ func (a *Autopilot) beginExecution(ctx context.Context, exec *execInfo) {
 
 		a.logger.Debug("autopilot is now stopped")
 
-		// We need to gain this lock so that we can nil out the previous state.
+		// We need to gain this lock so that we can zero out the previous state.
 		// This prevents us from accidentally tracking stale state in the event
 		// that we used to be the leader at some point in time, then weren't
 		// and now are again. In particular this will ensure that that we forget
@@ -140,7 +140,7 @@ func (a *Autopilot) beginExecution(ctx context.Context, exec *execInfo) {
 		// back at the beginning of this function.
 		a.stateLock.Lock()
 		defer a.stateLock.Unlock()
-		a.state = nil
+		a.state = &State{}
 
 		a.finishExecution(exec)
 		a.leaderLock.Unlock()


### PR DESCRIPTION
During New we initialize to a non-nil state so during shutdown we should put it back in that state instead of nil.

The buildServerState function relies on it not being nil. We could have added a nil check there but since we already initialize to non nil it seemed better to reinitialize instead of account for the nil elsewhere.

For background context this is non-nil so that things can use the GetState function to retrieve a pointer to the current state with us never overwriting the state that we have already given out to callers. We could have the state be a non-pointer member but then GetState would need to perform a copy. I still think I prefer the pointer approach.

The changes to the life cycle test are to exercise an actual restart which is where the panic was triggered before. Without the fix the test panics, with the fix its all fine.