### PR TITLE
Allow running autopilot with reconciliation disabled on non-leaders

### DIFF
--- a/autopilot_test.go
+++ b/autopilot_test.go
@@ -22,3 +22,18 @@ func TestRemoveDeadServerTrigger(t *testing.T) {
 
 	require.True(t, chanIsSelectable(ap.removeDeadCh))
 }
+
+func TestDisabledReconcilation(t *testing.T) {
+	logger := testLogger(t)
+	ap := New(NewMockRaft(t), NewMockApplicationIntegration(t), WithLogger(logger), WithReconciliationDisabled())
+	require.False(t, ap.ReconciliationEnabled())
+
+	ap.EnableReconciliation()
+	require.True(t, ap.ReconciliationEnabled())
+
+	ap.DisableReconciliation()
+	require.False(t, ap.ReconciliationEnabled())
+
+	ap = New(NewMockRaft(t), NewMockApplicationIntegration(t), WithLogger(logger))
+	require.True(t, ap.ReconciliationEnabled())
+}

--- a/mock_raft_test.go
+++ b/mock_raft_test.go
@@ -138,6 +138,20 @@ func (_m *MockRaft) RemoveServer(id raft.ServerID, prevIndex uint64, timeout tim
 	return r0
 }
 
+// State provides a mock function with given fields:
+func (_m *MockRaft) State() raft.RaftState {
+	ret := _m.Called()
+
+	var r0 raft.RaftState
+	if rf, ok := ret.Get(0).(func() raft.RaftState); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(raft.RaftState)
+	}
+
+	return r0
+}
+
 // Stats provides a mock function with given fields:
 func (_m *MockRaft) Stats() map[string]string {
 	ret := _m.Called()

--- a/raft_test.go
+++ b/raft_test.go
@@ -43,7 +43,7 @@ func mockedRaftAutopilot(t *testing.T) (*Autopilot, *MockRaft) {
 	mdel := NewMockApplicationIntegration(t)
 	mraft := NewMockRaft(t)
 
-	return New(mraft, mdel), mraft
+	return New(mraft, mdel, WithLogger(testLogger(t))), mraft
 }
 
 func TestNumVoters(t *testing.T) {

--- a/reconcile.go
+++ b/reconcile.go
@@ -9,6 +9,10 @@ import (
 
 // reconcile calculates and then applies promotions and demotions
 func (a *Autopilot) reconcile() error {
+	if !a.ReconciliationEnabled() {
+		return nil
+	}
+
 	conf := a.delegate.AutopilotConfig()
 	if conf == nil {
 		return nil
@@ -221,6 +225,10 @@ func (a *Autopilot) getFailedServers() (*FailedServers, int, error) {
 // Additionally the delegate will be consulted to determine if all of the removals should be done and
 // can filter the failed servers listings if need be.
 func (a *Autopilot) pruneDeadServers() error {
+	if !a.ReconciliationEnabled() {
+		return nil
+	}
+
 	conf := a.delegate.AutopilotConfig()
 	if conf == nil || !conf.CleanupDeadServers {
 		return nil

--- a/run_test.go
+++ b/run_test.go
@@ -119,6 +119,7 @@ func TestRunLifeCycle(t *testing.T) {
 						Version:     "1.9.0",
 						RaftVersion: 3,
 						NodeType:    NodeVoter,
+						IsLeader:    true,
 					},
 					State:  RaftLeader,
 					Stats:  *serverStats["7875975d-d54b-49c1-a400-9fefcc706c67"],
@@ -170,6 +171,7 @@ func TestRunLifeCycle(t *testing.T) {
 	mraft.On("GetConfiguration").Return(&raftConfigFuture{config: test3VoterRaftConfiguration}).Times(2)
 	mdel.On("KnownServers").Return(servers).Times(2)
 	mraft.On("LastIndex").Return(lastIndex).Times(2)
+	mraft.On("State").Return(raft.Leader).Times(2)
 	mraft.On("Stats").Return(map[string]string{"last_log_term": "3"}).Times(2)
 	mdel.On("FetchServerStats", mock.Anything, servers).Return(serverStats).Times(2)
 	mraft.On("Leader").Return(leaderAddr).Times(2)

--- a/testdata/no-leader/inputs.json
+++ b/testdata/no-leader/inputs.json
@@ -100,6 +100,6 @@
          "LastIndex": 999
       }
    },
-   "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67",
-   "IsLeader": true
+   "LeaderID": "",
+   "IsLeader": false
 }

--- a/testdata/no-leader/state.json.golden
+++ b/testdata/no-leader/state.json.golden
@@ -1,5 +1,5 @@
 {
-   "Healthy": true,
+   "Healthy": false,
    "FailureTolerance": 0,
    "Servers": {
       "7875975d-d54b-49c1-a400-9fefcc706c67": {
@@ -11,18 +11,18 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
-            "IsLeader": true,
+            "IsLeader": false,
             "NodeType": "voter",
             "Ext": null
          },
-         "State": "leader",
+         "State": "voter",
          "Stats": {
             "LastContact": 0,
             "LastTerm": 3,
             "LastIndex": 1024
          },
          "Health": {
-            "Healthy": true,
+            "Healthy": false,
             "StableSince": "2020-11-02T15:00:00Z"
          }
       },
@@ -39,14 +39,14 @@
             "NodeType": "voter",
             "Ext": null
          },
-         "State": "non-voter",
+         "State": "voter",
          "Stats": {
             "LastContact": 15000000,
             "LastTerm": 3,
             "LastIndex": 999
          },
          "Health": {
-            "Healthy": true,
+            "Healthy": false,
             "StableSince": "2020-11-02T15:00:00Z"
          }
       },
@@ -70,14 +70,15 @@
             "LastIndex": 1000
          },
          "Health": {
-            "Healthy": true,
+            "Healthy": false,
             "StableSince": "2020-11-02T15:00:00Z"
          }
       }
    },
-   "Leader": "7875975d-d54b-49c1-a400-9fefcc706c67",
+   "Leader": "",
    "Voters": [
       "7875975d-d54b-49c1-a400-9fefcc706c67",
+      "e72eb8da-604d-47cd-bd7f-69ec120ea2b7",
       "ecfc5237-63c3-4b09-94b9-d5682d9ae5b1"
    ],
    "Ext": null

--- a/testdata/not-the-leader/inputs.json
+++ b/testdata/not-the-leader/inputs.json
@@ -82,7 +82,7 @@
          "RaftVersion": 3
       }
    },
-   "LatestIndex": 1024,
+   "LatestIndex": 500,
    "LastTerm": 3,
    "FetchedStats": {
       "7875975d-d54b-49c1-a400-9fefcc706c67": {
@@ -97,9 +97,9 @@
       "e72eb8da-604d-47cd-bd7f-69ec120ea2b7": {
          "LastContact": 15000000,
          "LastTerm": 3,
-         "LastIndex": 999
+         "LastIndex": 500
       }
    },
    "LeaderID": "7875975d-d54b-49c1-a400-9fefcc706c67",
-   "IsLeader": true
+   "IsLeader": false
 }

--- a/testdata/not-the-leader/state.json.golden
+++ b/testdata/not-the-leader/state.json.golden
@@ -1,5 +1,5 @@
 {
-   "Healthy": true,
+   "Healthy": false,
    "FailureTolerance": 0,
    "Servers": {
       "7875975d-d54b-49c1-a400-9fefcc706c67": {
@@ -39,14 +39,14 @@
             "NodeType": "voter",
             "Ext": null
          },
-         "State": "non-voter",
+         "State": "voter",
          "Stats": {
             "LastContact": 15000000,
             "LastTerm": 3,
-            "LastIndex": 999
+            "LastIndex": 500
          },
          "Health": {
-            "Healthy": true,
+            "Healthy": false,
             "StableSince": "2020-11-02T15:00:00Z"
          }
       },
@@ -78,7 +78,8 @@
    "Leader": "7875975d-d54b-49c1-a400-9fefcc706c67",
    "Voters": [
       "7875975d-d54b-49c1-a400-9fefcc706c67",
-      "ecfc5237-63c3-4b09-94b9-d5682d9ae5b1"
+      "ecfc5237-63c3-4b09-94b9-d5682d9ae5b1",
+      "e72eb8da-604d-47cd-bd7f-69ec120ea2b7"
    ],
    "Ext": null
 }

--- a/testdata/one-failed/state.json.golden
+++ b/testdata/one-failed/state.json.golden
@@ -11,7 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
-            "IsLeader": false,
+            "IsLeader": true,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/staging/state.json.golden
+++ b/testdata/staging/state.json.golden
@@ -11,7 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
-            "IsLeader": false,
+            "IsLeader": true,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/state-overrides/state.json.golden
+++ b/testdata/state-overrides/state.json.golden
@@ -11,7 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
-            "IsLeader": false,
+            "IsLeader": true,
             "NodeType": "voter",
             "Ext": null
          },

--- a/testdata/typical/state.json.golden
+++ b/testdata/typical/state.json.golden
@@ -11,7 +11,7 @@
             "Version": "1.9.0",
             "Meta": null,
             "RaftVersion": 3,
-            "IsLeader": false,
+            "IsLeader": true,
             "NodeType": "voter",
             "Ext": null
          },

--- a/types.go
+++ b/types.go
@@ -108,19 +108,28 @@ func (s *ServerState) HasVotingRights() bool {
 // isHealthy determines whether this ServerState is considered healthy
 // based on the given Autopilot config
 func (s *ServerState) isHealthy(lastTerm uint64, leaderLastIndex uint64, conf *Config) bool {
+	// Raft hasn't been bootstrapped yet so nothing is healthy
+	if leaderLastIndex == 0 || lastTerm == 0 {
+		return false
+	}
+
+	// Check that the application still thinks the server is alive and well.
 	if s.Server.NodeStatus != NodeAlive {
 		return false
 	}
 
+	// Check to ensure that the server was contacted recently enough.
 	if s.Stats.LastContact > conf.LastContactThreshold || s.Stats.LastContact < 0 {
 		return false
 	}
 
+	// Check if the server has a different Raft term from the leader
 	if s.Stats.LastTerm != lastTerm {
 		return false
 	}
 
-	if leaderLastIndex > conf.MaxTrailingLogs && s.Stats.LastIndex < leaderLastIndex-conf.MaxTrailingLogs {
+	// Check if the server has fallen behind more than the configured max trailing logs value
+	if s.Stats.LastIndex+conf.MaxTrailingLogs < leaderLastIndex {
 		return false
 	}
 
@@ -203,6 +212,7 @@ type Raft interface {
 	RemoveServer(id raft.ServerID, prevIndex uint64, timeout time.Duration) raft.IndexFuture
 	Stats() map[string]string
 	LeadershipTransferToServer(id raft.ServerID, address raft.ServerAddress) raft.Future
+	State() raft.RaftState
 }
 
 type ApplicationIntegration interface {


### PR DESCRIPTION
The goal of this PR is to enable a mode of operation where autopilot can keep its state up to date even when running on a Raft follower. In this mode autopilot will still calculate health of other nodes and generally track servers as they come and go.  What it will not do is attempt to perform any Raft operations that would alter the configuration, or request that the application remove failed servers.

Also of note is that you have to opt-in to this behavior. By default when you call `Start` on an `Autopilot` instance it will be performing both the state updating as well as the reconciliation. In order to opt-in you can pass `WithReconciliationDisabled()` as an option to `New` or you can call `Autopilot.DisableReconciliation()`. When a server transitions from being a follower to the leader you then call `Autopilot.EnableReconciliation()` to enable that functionality again.
