### PR TITLE
SEC-090: Automated trusted workflow pinning (2023-03-10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   go-fmt-and-vet:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version-file: 'go.mod'
         cache: true
@@ -29,8 +29,8 @@ jobs:
     needs: go-fmt-and-vet
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version-file: 'go.mod'
         cache: true


### PR DESCRIPTION
This PR pins action references in workflow and action files to SHAs.
This is in support of [SEC-090](https://github.com/hashicorp/security-tsccr/issues/214);
Any questions please reach out to [#team-prodsec](https://go.hashi.co/team-prodsec)
