### PR TITLE
Fix nil dereference in adjudicateRemoval for unknown server IDs

### DIFF
--- a/reconcile.go
+++ b/reconcile.go
@@ -332,7 +332,7 @@ func (a *Autopilot) adjudicateRemoval(ids []raft.ServerID, vr *voterRegistry) []
 
 		if v != nil && v.isPotentialVoter() && initialPotentialVoters-removedPotentialVoters-1 < int(minQuorum) {
 			a.logger.Debug("will not remove server node as it would leave less voters than the minimum number allowed", "id", id, "min", minQuorum)
-		} else if v.isCurrentVoter() && maxRemoval < 1 {
+		} else if v != nil && v.isCurrentVoter() && maxRemoval < 1 {
 			a.logger.Debug("will not remove server node as removal of a majority of voting servers is not safe", "id", id)
 		} else if v != nil && v.isPotentialVoter() {
 			maxRemoval--

--- a/reconcile_test.go
+++ b/reconcile_test.go
@@ -1047,3 +1047,24 @@ func TestPruneDeadServersDisabled(t *testing.T) {
 		WithReconciliationDisabled())
 	require.NoError(t, ap.pruneDeadServers())
 }
+
+func TestAdjudicateRemovalNilEligibility(t *testing.T) {
+	conf := &Config{MinQuorum: 3}
+	mapp := NewMockApplicationIntegration(t)
+	mapp.On("AutopilotConfig").Return(conf)
+
+	a := &Autopilot{
+		logger:   hclog.NewNullLogger(),
+		delegate: mapp,
+	}
+
+	vr := newVoterRegistry()
+	vr.eligibility["known-voter"] = &voterEligibility{
+		currentVoter:   true,
+		potentialVoter: true,
+	}
+
+	unknown := raft.ServerID("unknown-server")
+	got := a.adjudicateRemoval([]raft.ServerID{unknown}, vr)
+	require.Equal(t, []raft.ServerID{unknown}, got)
+}


### PR DESCRIPTION
## Summary
Fixes #61.

`adjudicateRemoval` checked `v != nil` on the first branch, then called `v.isCurrentVoter()` on the next branch without a nil guard. A server ID missing from `voterRegistry.eligibility` panics.

Guard the second branch the same way as the others so an unknown entry falls through to the removable path.

## Test plan
- [x] `go test -count=1 -run TestAdjudicateRemovalNilEligibility .` — RED (nil deref) on master, GREEN after
- [x] `go test -count=1 -skip TestRunLifeCycle .`